### PR TITLE
Moved common code into shared file

### DIFF
--- a/debiantools.py
+++ b/debiantools.py
@@ -4,14 +4,16 @@ from conans import AutoToolsBuildEnvironment, CMake, ConanFile, tools
 from conans.client.tools.oss import get_gnu_triplet
 
 def translate_arch(conanfile: ConanFile) -> str:
-    arch_names = {"x86_64": "amd64",
-                    "x86": "i386",
-                    "ppc32": "powerpc",
-                    "ppc64le": "ppc64el",
-                    "armv7": "arm",
-                    "armv7hf": "armhf",
-                    "armv8": "arm64",
-                    "s390x": "s390x"}
+    arch_names = {
+        "x86_64": "amd64",
+        "x86": "i386",
+        "ppc32": "powerpc",
+        "ppc64le": "ppc64el",
+        "armv7": "arm",
+        "armv7hf": "armhf",
+        "armv8": "arm64",
+        "s390x": "s390x"
+    }
     return arch_names[str(conanfile.settings.arch)]
     
 def download_extract_deb(conanfile: ConanFile, url: str, sha256: str) -> None:
@@ -25,9 +27,12 @@ def download_extract_deb(conanfile: ConanFile, url: str, sha256: str) -> None:
     tools.unzip(deb_data_file)
     os.unlink(deb_data_file)
 
-def triplet_name(conanfile: ConanFile) -> str:
+def triplet_name(conanfile: ConanFile, force_linux: bool=False) -> str:
     # we only need the autotool class to generate the host variable
     autotools = AutoToolsBuildEnvironment(conanfile)
+
+    if force_linux:
+        return get_gnu_triplet("Linux", str(conanfile.settings.arch), "gnu")
 
     # construct path using platform name, e.g. usr/lib/arm-linux-gnueabihf/pkgconfig
     # if not cross-compiling it will be false. In that case, construct the name by hand

--- a/libasound2/conanfile.py
+++ b/libasound2/conanfile.py
@@ -1,6 +1,11 @@
 import os
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.client.tools.oss import get_gnu_triplet
+from conans import ConanFile, tools
+try:
+    # we can only use this file when running conan install. When exporting this recipe, the file does not yet exist
+    # since it's in a different location and conan fails. In order to handle this, we need to catch this here
+    from debiantools import copy_cleaned, download_extract_deb, translate_arch, triplet_name
+except ImportError:
+    pass 
 
 class DebianDependencyConan(ConanFile):
     name = "libasound2"
@@ -12,36 +17,7 @@ class DebianDependencyConan(ConanFile):
     url = "https://github.com/totemic/conan-package-recipes/libasound2"    
     license = "GNU Lesser General Public License"
     settings = "os", "arch"
-
-    def translate_arch(self):
-        arch_names = {"x86_64": "amd64",
-                        "x86": "i386",
-                        "ppc32": "powerpc",
-                        "ppc64le": "ppc64el",
-                        "armv7": "arm",
-                        "armv7hf": "armhf",
-                        "armv8": "arm64",
-                        "s390x": "s390x"}
-        return arch_names[str(self.settings.arch)]
-        
-    def _download_extract_deb(self, url, sha256):
-        filename = "./download.deb"
-        deb_data_file = "data.tar.xz"
-        tools.download(url, filename)
-        tools.check_sha256(filename, sha256)
-        # extract the payload from the debian file
-        self.run("ar -x %s %s" % (filename, deb_data_file))
-        os.unlink(filename)
-        tools.unzip(deb_data_file)
-        os.unlink(deb_data_file)
-
-    def triplet_name(self):
-        # we only need the autotool class to generate the host variable
-        autotools = AutoToolsBuildEnvironment(self)
-
-        # construct path using platform name, e.g. usr/lib/arm-linux-gnueabihf/pkgconfig
-        # if not cross-compiling it will be false. In that case, construct the name by hand
-        return autotools.host or get_gnu_triplet(str(self.settings.os), str(self.settings.arch), self.settings.get_safe("compiler"))
+    exports = ["../debiantools.py"]
 
     def build(self):
         if self.settings.os == "Linux":
@@ -52,9 +28,9 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "efcae0522800ac0f32a72d7ac240375effde06473bb5aeabbe20d2d4057c185e"
 
                 url_lib = ("http://ftp.debian.org/debian/pool/main/a/alsa-lib/libasound2_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://ftp.debian.org/debian/pool/main/a/alsa-lib/libasound2-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
             elif self.settings.arch == "armv8":
                 # https://packages.debian.org/buster/arm64/libasound2/download
                 sha_lib = "af663d07d10b085f590c539772dbf70b279df187210ea818446dfd896487adee"
@@ -62,50 +38,35 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "617ed035bd7caaab64c7f68e5b673bd60160eb536b9e7ca3c748cc9c46949ffe"
 
                 url_lib = ("http://ftp.debian.org/debian/pool/main/a/alsa-lib/libasound2_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://ftp.debian.org/debian/pool/main/a/alsa-lib/libasound2-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-            else: # armv7hf
-                # https://packages.ubuntu.com/xenial/armhf/libasound2/download
-                sha_lib = "8aa152b840021ab3fbebe2d099a0106f226eec92551c36ce41d5d3310a059849"
-                # https://packages.ubuntu.com/xenial/armhf/libasound2-dev/download
-                sha_dev = "736d846de5bfcac933c9f35ac47b1e5f128901856ffce08f8865e8dfc8a15966"
-
-                url_lib = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/a/alsa-lib/libasound2_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-                url_dev = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/a/alsa-lib/libasound2-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
+            else:
+                raise Exception("Todo: add binary urls for this architecture")
         else:
             raise Exception("Binary does not exist for these settings")
-        self._download_extract_deb(url_lib, sha_lib)
-        self._download_extract_deb(url_dev, sha_dev)
+        download_extract_deb(self, url_lib, sha_lib)
+        download_extract_deb(self, url_dev, sha_dev)
 
     def package(self):
-        self.copy(pattern="*", dst="lib", src="usr/lib/" + self.triplet_name(), symlinks=True)
+        self.copy(pattern="*", dst="lib", src="usr/lib/" + triplet_name(self), symlinks=True)
         self.copy(pattern="*", dst="include", src="usr/include", symlinks=True)
         self.copy(pattern="copyright", src="usr/share/doc/" + self.name, symlinks=True)
 
-    def copy_cleaned(self, source, prefix_remove, dest):
-        for e in source:
-            if (e.startswith(prefix_remove)):
-                entry = e[len(prefix_remove):]
-                if len(entry) > 0 and not entry in dest:
-                    dest.append(entry)
-
     def package_info(self):
-        #pkgpath = "usr/lib/%s/pkgconfig" % self.triplet_name()
+        #pkgpath = "usr/lib/%s/pkgconfig" % triplet_name(self)
         pkgpath =  "lib/pkgconfig"
         pkgconfigpath = os.path.join(self.package_folder, pkgpath)
         self.output.info("package info file: " + pkgconfigpath)
         with tools.environment_append({'PKG_CONFIG_PATH': pkgconfigpath}):
             pkg_config = tools.PkgConfig("alsa", variables={ "prefix" : self.package_folder } )
 
-            self.copy_cleaned(pkg_config.libs_only_L, "-L", self.cpp_info.lib_paths)
+            copy_cleaned(pkg_config.libs_only_L, "-L", self.cpp_info.lib_paths)
             self.output.info("lib_paths %s" % self.cpp_info.lib_paths)
 
             # exclude all libraries from dependencies here, they are separately included
-            self.copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
+            copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
             self.output.info("libs: %s" % self.cpp_info.libs)
 
-            self.copy_cleaned(pkg_config.cflags_only_I, "-I", self.cpp_info.include_paths)
+            copy_cleaned(pkg_config.cflags_only_I, "-I", self.cpp_info.include_paths)
             self.output.info("include_paths: %s" % self.cpp_info.include_paths)

--- a/libpulse0/conanfile.py
+++ b/libpulse0/conanfile.py
@@ -1,5 +1,5 @@
 import os
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans import ConanFile, tools
 try:
     # we can only use this file when running conan install. When exporting this recipe, the file does not yet exist
     # since it's in a different location and conan fails. In order to handle this, we need to catch this here
@@ -33,7 +33,7 @@ class DebianDependencyConan(ConanFile):
                 # https://packages.debian.org/buster/arm64/libpulse-dev/download
                 sha_dev = "ada3da8f3245ce82fda28f2ef494029213c8a4acb16bf66bb9c6664138749182"
             else:
-                raise Exception("Todo: add binary urls for these architecture")
+                raise Exception("Todo: add binary urls for this architecture")
 
             url_lib = ("http://ftp.debian.org/debian/pool/main/p/pulseaudio/libpulse0_%s-%s_%s.deb"
                 % (str(self.version), self.build_version, translate_arch(self)))

--- a/libsystemd0/conanfile.py
+++ b/libsystemd0/conanfile.py
@@ -1,6 +1,11 @@
 import os
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.client.tools.oss import get_gnu_triplet
+from conans import ConanFile, tools
+try:
+    # we can only use this file when running conan install. When exporting this recipe, the file does not yet exist
+    # since it's in a different location and conan fails. In order to handle this, we need to catch this here
+    from debiantools import copy_cleaned, download_extract_deb, translate_arch, triplet_name
+except ImportError:
+    pass 
 
 class DebianDependencyConan(ConanFile):
     name = "libsystemd0"
@@ -12,6 +17,7 @@ class DebianDependencyConan(ConanFile):
     url = "https://github.com/totemic/conan-package-recipes/libsystemd0"    
     license = "LGPL"
     settings = "os", "arch"
+    exports = ["../debiantools.py"]
 
     def requirements(self):
         if self.settings.os == "Linux":
@@ -19,36 +25,6 @@ class DebianDependencyConan(ConanFile):
             # right now this is handled by telling the linker to ignore unknown symbols in secondary dependencies
             self.requires("libudev1/237@totemic/stable")
 
-    def translate_arch(self):
-        arch_string = str(self.settings.arch)
-        # ubuntu does not have v7 specific libraries
-        if (arch_string) == "armv7hf":
-            return "armhf"
-        elif (arch_string) == "armv8":
-            return "arm64"
-        elif (arch_string) == "x86_64":
-            return "amd64"
-        return arch_string
-        
-    def _download_extract_deb(self, url, sha256):
-        filename = "./download.deb"
-        deb_data_file = "data.tar.xz"
-        tools.download(url, filename)
-        tools.check_sha256(filename, sha256)
-        # extract the payload from the debian file
-        self.run("ar -x %s %s" % (filename, deb_data_file))
-        os.unlink(filename)
-        tools.unzip(deb_data_file)
-        os.unlink(deb_data_file)
-
-    def triplet_name(self):
-        # we only need the autotool class to generate the host variable
-        autotools = AutoToolsBuildEnvironment(self)
-
-        # construct path using platform name, e.g. usr/lib/arm-linux-gnueabihf/pkgconfig
-        # if not cross-compiling it will be false. In that case, construct the name by hand
-        return autotools.host or get_gnu_triplet(str(self.settings.os), str(self.settings.arch), self.settings.get_safe("compiler"))
-        
     def build(self):
         if self.settings.os == "Linux":
             if self.settings.arch == "x86_64":
@@ -58,9 +34,9 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "32f1f3f917c5f0d7b53e4bfb1f1087159e365d89405ec85acf0bd43dee0fbac0"
 
                 url_lib = ("http://us.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libsystemd0_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://us.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libsystemd-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
             elif self.settings.arch == "armv8":
                 # https://packages.ubuntu.com/bionic-updates/arm64/libsystemd0/download
                 sha_lib = "2ec53633f7ad8998159ac65da5a7dbd545abdf6e250382c0a70d8be6dbe74185"
@@ -68,23 +44,16 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "2c3c39e385b61826862dac7f5f480fa925810d41666acc0c29b0ff58c13c0aa1"
 
                 url_lib = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libsystemd0_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libsystemd-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-            else: # armv7hf
-                # https://packages.ubuntu.com/bionic-updates/armhf/libsystemd0/download
-                sha_lib = "e5f18ce43d7096a19f24220950031cdf0b2e64dbd2aebb8019766d70195f872a"
-                # https://packages.ubuntu.com/bionic-updates/armhf/libsystemd-dev/download
-                sha_dev = "b364f540067e25bf63332b61a920951d33cc0ff8d2d868ccdd8067618299b9f8"
+                   % (str(self.version), self.build_version, translate_arch(self)))
+            else:
+                raise Exception("Todo: add binary urls for this architecture")
 
-                url_lib = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libsystemd0_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-                url_dev = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libsystemd-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-            self._download_extract_deb(url_lib, sha_lib)
-            self._download_extract_deb(url_dev, sha_dev)
+            download_extract_deb(self, url_lib, sha_lib)
+            download_extract_deb(self, url_dev, sha_dev)
             # remove libsystemd.so which is an absolute link to /lib/aarch64-linux-gnu/libsystemd.so.0.14.0
-            # libsystemd_so_path = "lib/%s/libsystemd.so" % self.triplet_name()
+            # libsystemd_so_path = "lib/%s/libsystemd.so" % triplet_name(self)
             # os.remove(libsystemd_so_path)
             # os.symlink("libsystemd.so.0.21.0", libsystemd_so_path)
         else:
@@ -93,8 +62,8 @@ class DebianDependencyConan(ConanFile):
             self.output.info("Nothing to be done for this OS")
 
     def package(self):
-        self.copy(pattern="*", dst="lib", src="lib/" + self.triplet_name(), symlinks=True)
-        self.copy(pattern="*", dst="lib", src="usr/lib/" + self.triplet_name(), symlinks=True)
+        self.copy(pattern="*", dst="lib", src="lib/" + triplet_name(self), symlinks=True)
+        self.copy(pattern="*", dst="lib", src="usr/lib/" + triplet_name(self), symlinks=True)
         self.copy(pattern="*", dst="include", src="usr/include", symlinks=True)
         self.copy(pattern="copyright", src="usr/share/doc/" + self.name, symlinks=True)
 
@@ -122,7 +91,7 @@ class DebianDependencyConan(ConanFile):
                 self.output.info("lib_paths %s" % self.cpp_info.lib_paths)
 
                 # exclude all libraries from dependencies here, they are separately included
-                self.copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
+                copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
                 self.output.info("libs: %s" % self.cpp_info.libs)
 
                 self.output.info("include_paths: %s" % self.cpp_info.include_paths)

--- a/libudev1/conanfile.py
+++ b/libudev1/conanfile.py
@@ -1,6 +1,11 @@
 import os
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.client.tools.oss import get_gnu_triplet
+from conans import ConanFile, tools
+try:
+    # we can only use this file when running conan install. When exporting this recipe, the file does not yet exist
+    # since it's in a different location and conan fails. In order to handle this, we need to catch this here
+    from debiantools import copy_cleaned, download_extract_deb, translate_arch, triplet_name
+except ImportError:
+    pass 
 
 class DebianDependencyConan(ConanFile):
     name = "libudev1"
@@ -12,41 +17,12 @@ class DebianDependencyConan(ConanFile):
     url = "https://github.com/totemic/conan-package-recipes/libudev1"    
     license = "LGPL"
     settings = "os", "arch"
+    exports = ["../debiantools.py"]
 
     def configure(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("This library is only supported on Linux")
 
-    def translate_arch(self):
-        arch_string = str(self.settings.arch)
-        # ubuntu does not have v7 specific libraries
-        if (arch_string) == "armv7hf":
-            return "armhf"
-        elif (arch_string) == "armv8":
-            return "arm64"
-        elif (arch_string) == "x86_64":
-            return "amd64"
-        return arch_string
-        
-    def _download_extract_deb(self, url, sha256):
-        filename = "./download.deb"
-        deb_data_file = "data.tar.xz"
-        tools.download(url, filename)
-        tools.check_sha256(filename, sha256)
-        # extract the payload from the debian file
-        self.run("ar -x %s %s" % (filename, deb_data_file))
-        os.unlink(filename)
-        tools.unzip(deb_data_file)
-        os.unlink(deb_data_file)
-
-    def triplet_name(self):
-        # we only need the autotool class to generate the host variable
-        autotools = AutoToolsBuildEnvironment(self)
-
-        # construct path using platform name, e.g. usr/lib/arm-linux-gnueabihf/pkgconfig
-        # if not cross-compiling it will be false. In that case, construct the name by hand
-        return autotools.host or get_gnu_triplet(str(self.settings.os), str(self.settings.arch), self.settings.get_safe("compiler"))
-        
     def build(self):
         if self.settings.os == "Linux":
             if self.settings.arch == "x86_64":
@@ -56,9 +32,9 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "99094f5144d0b9857ebc65415a2a331be8b5595f63e12a574243905fded2fd1b"
                 
                 url_lib = ("http://us.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev1_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://us.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
             elif self.settings.arch == "armv8":
                 # https://packages.ubuntu.com/bionic-updates/arm64/libudev1/download
                 sha_lib = "0ce8fd96fc131cf8887ec181900d7b566385cc628ab0f7316266fe102ed8cbfe"
@@ -66,27 +42,20 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "9f134e6de6bed76cd63e3a3ec74500e82c80c516b23346ade709b0cc4b3e2129"
                 
                 url_lib = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libudev1_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libudev-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-            else: # armv7hf
-                # https://packages.ubuntu.com/bionic-updates/armhf/libudev1/download
-                sha_lib = "b07efd0fa9f87f4804c7c7819661c2cd3d4d7331b76b438b9eba702701f625a2"
-                # https://packages.ubuntu.com/bionic-updates/armhf/libudev-dev/download
-                sha_dev = "e1c933369ef835b33dd9b0c4caea2c39988e0be73981699d20bfea124f41d97d"
-                
-                url_lib = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libudev1_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-                url_dev = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/s/systemd/libudev-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-            self._download_extract_deb(url_lib, sha_lib)
-            self._download_extract_deb(url_dev, sha_dev)
+                   % (str(self.version), self.build_version, translate_arch(self)))
+            else:
+                raise Exception("Todo: add binary urls for this architecture")
+
+            download_extract_deb(self, url_lib, sha_lib)
+            download_extract_deb(self, url_dev, sha_dev)
         else:
             self.output.info("Nothing to be done for this OS")
 
     def package(self):
-        self.copy(pattern="*", dst="lib", src="lib/" + self.triplet_name(), symlinks=True)
-        self.copy(pattern="*", dst="lib", src="usr/lib/" + self.triplet_name(), symlinks=True)
+        self.copy(pattern="*", dst="lib", src="lib/" + triplet_name(self), symlinks=True)
+        self.copy(pattern="*", dst="lib", src="usr/lib/" + triplet_name(self), symlinks=True)
         self.copy(pattern="*", dst="include", src="usr/include", symlinks=True)
         self.copy(pattern="copyright", src="usr/share/doc/" + self.name, symlinks=True)
 
@@ -98,7 +67,7 @@ class DebianDependencyConan(ConanFile):
                     dest.append(entry)
 
     def package_info(self):
-        # pkgpath = "usr/lib/%s/pkgconfig" % self.triplet_name()
+        # pkgpath = "usr/lib/%s/pkgconfig" % triplet_name(self)
         pkgpath =  "lib/pkgconfig"
         pkgconfigpath = os.path.join(self.package_folder, pkgpath)
         if self.settings.os == "Linux":
@@ -109,7 +78,7 @@ class DebianDependencyConan(ConanFile):
                 self.output.info("lib_paths %s" % self.cpp_info.lib_paths)
 
                 # exclude all libraries from dependencies here, they are separately included
-                self.copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
+                copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
                 self.output.info("libs: %s" % self.cpp_info.libs)
 
                 self.output.info("include_paths: %s" % self.cpp_info.include_paths)

--- a/libuuid1/conanfile.py
+++ b/libuuid1/conanfile.py
@@ -1,6 +1,11 @@
 import os
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.client.tools.oss import get_gnu_triplet
+from conans import ConanFile, tools
+try:
+    # we can only use this file when running conan install. When exporting this recipe, the file does not yet exist
+    # since it's in a different location and conan fails. In order to handle this, we need to catch this here
+    from debiantools import copy_cleaned, download_extract_deb, translate_arch, triplet_name
+except ImportError:
+    pass 
 
 class DebianDependencyConan(ConanFile):
     name = "libuuid1"
@@ -12,37 +17,8 @@ class DebianDependencyConan(ConanFile):
     url = "https://github.com/totemic/conan-package-recipes/libuuid1"    
     license = "BSD-3-clause"
     settings = "os", "arch"
+    exports = ["../debiantools.py"]
 
-    def translate_arch(self):
-        arch_string = str(self.settings.arch)
-        # ubuntu does not have v7 specific libraries
-        if (arch_string) == "armv7hf":
-            return "armhf"
-        elif (arch_string) == "armv8":
-            return "arm64"
-        elif (arch_string) == "x86_64":
-            return "amd64"
-        return arch_string
-        
-    def _download_extract_deb(self, url, sha256):
-        filename = "./download.deb"
-        deb_data_file = "data.tar.xz"
-        tools.download(url, filename)
-        tools.check_sha256(filename, sha256)
-        # extract the payload from the debian file
-        self.run("ar -x %s %s" % (filename, deb_data_file))
-        os.unlink(filename)
-        tools.unzip(deb_data_file)
-        os.unlink(deb_data_file)
-
-    def triplet_name(self):
-        # we only need the autotool class to generate the host variable
-        autotools = AutoToolsBuildEnvironment(self)
-
-        # construct path using platform name, e.g. usr/lib/arm-linux-gnueabihf/pkgconfig
-        # if not cross-compiling it will be false. In that case, construct the name by hand
-        return autotools.host or get_gnu_triplet(str(self.settings.os), str(self.settings.arch), self.settings.get_safe("compiler"))
-        
     def build(self):
         if self.settings.os == "Linux":
             if self.settings.arch == "x86_64":
@@ -52,9 +28,9 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "a9d5d94c8181fcafa7464fb3298a36ece0ff64f1df7d599fe7258fa91dc23d62"
                 
                 url_lib = ("http://us.archive.ubuntu.com/ubuntu/pool/main/u/util-linux/libuuid1_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://us.archive.ubuntu.com/ubuntu/pool/main/u/util-linux/uuid-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
             elif self.settings.arch == "armv8":
                 # https://packages.ubuntu.com/xenial-updates/arm64/libuuid1/download
                 sha_lib = "1d886309c5b24257e5cc6ba0aa27085b01fc4702049b780e01fef2dce52b0c70"
@@ -62,31 +38,24 @@ class DebianDependencyConan(ConanFile):
                 sha_dev = "8086d900b015b4be3a78c43c4a8a41954998a8d978e42c4d82b513468d8dc6a4"
                 
                 url_lib = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/u/util-linux/libuuid1_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
+                   % (str(self.version), self.build_version, translate_arch(self)))
                 url_dev = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/u/util-linux/uuid-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-            else: # armv7hf
-                # https://packages.ubuntu.com/xenial-updates/armhf/libuuid1/download
-                sha_lib = "029dfbd95f619bdaf54a663dd5a92a5ec1d45447deeb81383e338c7aed5741b6"
-                # https://packages.ubuntu.com/xenial-updates/armhf/uuid-dev/download
-                sha_dev = "3b6ffd5b606ede5d0f3d9c4284bfd5a75a3cbc45bfd7aa008ac943f0b0c97912"
-                
-                url_lib = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/u/util-linux/libuuid1_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-                url_dev = ("http://ports.ubuntu.com/ubuntu-ports/pool/main/u/util-linux/uuid-dev_%s-%s_%s.deb"
-                   % (str(self.version), self.build_version, self.translate_arch()))
-            self._download_extract_deb(url_lib, sha_lib)
-            self._download_extract_deb(url_dev, sha_dev)
+                   % (str(self.version), self.build_version, translate_arch(self)))
+            else:
+                raise Exception("Todo: add binary urls for this architecture")
+
+            download_extract_deb(self, url_lib, sha_lib)
+            download_extract_deb(self, url_dev, sha_dev)
             # remove libuuid.so which is an absolute link to /lib/arm-linux-gnueabihf/libuuid.so.1.3.0
-            libuuid_so_path = "usr/lib/%s/libuuid.so" % self.triplet_name()
+            libuuid_so_path = "usr/lib/%s/libuuid.so" % triplet_name(self)
             os.remove(libuuid_so_path)
             os.symlink("libuuid.so.1.3.0", libuuid_so_path)
         else:
             self.output.info("Nothing to be done for this OS")
 
     def package(self):
-        self.copy(pattern="*", dst="lib", src="lib/" + self.triplet_name(), symlinks=True)
-        self.copy(pattern="*", dst="lib", src="usr/lib/" + self.triplet_name(), symlinks=True)
+        self.copy(pattern="*", dst="lib", src="lib/" + triplet_name(self), symlinks=True)
+        self.copy(pattern="*", dst="lib", src="usr/lib/" + triplet_name(self), symlinks=True)
         self.copy(pattern="*", dst="include", src="usr/include", symlinks=True)
         self.copy(pattern="copyright", src="usr/share/doc/" + self.name, symlinks=True)
 
@@ -98,7 +67,7 @@ class DebianDependencyConan(ConanFile):
                     dest.append(entry)
 
     def package_info(self):
-        # pkgpath = "usr/lib/%s/pkgconfig" % self.triplet_name()
+        # pkgpath = "usr/lib/%s/pkgconfig" % triplet_name(self)
         pkgpath =  "lib/pkgconfig"
         pkgconfigpath = os.path.join(self.package_folder, pkgpath)
         if self.settings.os == "Linux":
@@ -106,12 +75,12 @@ class DebianDependencyConan(ConanFile):
             with tools.environment_append({'PKG_CONFIG_PATH': pkgconfigpath}):
                 pkg_config = tools.PkgConfig("uuid", variables={ "prefix" : self.package_folder } )
 
-                #self.copy_cleaned(pkg_config.libs_only_L, "-L", self.cpp_info.lib_paths)
+                #copy_cleaned(pkg_config.libs_only_L, "-L", self.cpp_info.lib_paths)
                 self.output.info("lib_paths %s" % self.cpp_info.lib_paths)
 
                 # exclude all libraries from dependencies here, they are separately included
-                self.copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
+                copy_cleaned(pkg_config.libs_only_l, "-l", self.cpp_info.libs)
                 self.output.info("libs: %s" % self.cpp_info.libs)
 
-                #self.copy_cleaned(pkg_config.cflags_only_I, "-I", self.cpp_info.include_paths)
+                #copy_cleaned(pkg_config.cflags_only_I, "-I", self.cpp_info.include_paths)
                 self.output.info("include_paths: %s" % self.cpp_info.include_paths)


### PR DESCRIPTION
I have moved some of our external conan dependencies into a common repo. This gives us the ability to share some of the common installation code behind it. For a start, all the debian package dowloading is now sharing code. There's still a lot of things we can do but I wanted to make the first step. 