### PR TITLE
`libedgetpu` recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ test_package/__pycache__/*
 test_package/build/*
 test_package/*.pyc
 *.pyc
+
+# Local step-by-step testing of recipes
+build/
+source/
+package/

--- a/libedgetpu/README.md
+++ b/libedgetpu/README.md
@@ -1,0 +1,47 @@
+# libedgetpu
+
+## Package creation
+
+To test the creation of a package locally using a step-by-step approach, run the following steps:
+
+```shell
+# Get dependencies, set target version/user, set settings/options/profiles
+conan install . <version>@totemic/stable -if build --build=outdated [--profile=<profile> --profile:build=default]
+
+# Fetch source and apply patches
+conan source . -if build -sf source
+
+# Build targets
+conan build . -bf build -sf source -pf package
+
+# Package headers, libs, binaries ...
+conan package . -bf build -sf source -pf package
+```
+you can then inspect the contents of the package by browsing the `package` folder.
+
+Alternatively, you can build the package in one step with the following single command:
+```shell
+# Create package with specified version/user and settings/options/profiles
+conan create . <version>@totemic/stable --build=outdated [--profile=<profile> --profile:build=default]
+```
+
+The `conan create` command shares the same options as the `conan install` but runs the build within the
+local conan cache under `~/.conan/data/<package>/<version>/<user>/<channel>`, and because of this reason you don't
+need to specify folder paths
+
+Note: when cross-compiling, [it's common practice to specify a build profile](https://docs.conan.io/en/latest/systems_cross_building/cross_building.html#using-a-profile),
+otherwise the host profile will be used for build tools as well, which is not desired as
+they should run on the build machine
+
+## Examples
+
+```shell
+# Build for local machine
+conan create . grouper@totemic/stable --build=outdated
+
+# Build against specific tensorflow-lite version
+conan create . grouper@totemic/stable --build=outdated --require-override tensorflow-lite/2.8.0
+
+# Cross compile package (remember to specify build profile too)
+conan create . grouper@totemic/stable --build=outdated --profile=armv8-cc --profile:build=default
+```

--- a/libedgetpu/README.md
+++ b/libedgetpu/README.md
@@ -16,9 +16,6 @@ conan build . -bf build -sf source -pf package
 
 # Package headers, libs, binaries ...
 conan package . -bf build -sf source -pf package
-
-# Run package consumption test
-conan test test_package libedgetpu/<version>@totemic/stable
 ```
 you can then inspect the contents of the package by browsing the `package` folder.
 

--- a/libedgetpu/README.md
+++ b/libedgetpu/README.md
@@ -16,6 +16,9 @@ conan build . -bf build -sf source -pf package
 
 # Package headers, libs, binaries ...
 conan package . -bf build -sf source -pf package
+
+# Run package consumption test
+conan test test_package libedgetpu/<version>@totemic/stable
 ```
 you can then inspect the contents of the package by browsing the `package` folder.
 

--- a/libedgetpu/conandata.yml
+++ b/libedgetpu/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "grouper":
+    url: "https://github.com/google-coral/libedgetpu/archive/refs/tags/release-grouper.tar.gz"
+    sha256: "86a6e654e093c204b4fb579a60773bfa080f095c9cbb3a2c114ca4a13e0b15eb"

--- a/libedgetpu/conanfile.py
+++ b/libedgetpu/conanfile.py
@@ -1,0 +1,125 @@
+import os
+from os.path import join
+
+from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conans.errors import ConanInvalidConfiguration
+
+
+class EdgeTpuConan(ConanFile):
+    name = "libedgetpu"
+    description = "Source code for the userspace level runtime driver for Coral devices."
+    license = "Apache-2.0"
+    topics = ("machine-learning", "neural-networks", "deep-learning")
+
+    homepage = "https://github.com/google-coral/libedgetpu"
+    url = "https://github.com/totemic/conan-package-recipes"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {'throttled': [True, False]}
+    default_options = {'throttled': False}
+
+    exports = ["patches/*"]
+
+    tf_revisions = {
+        "2.6.2": dict(commit="c2363d6d025981c661f8cbecf4c73ca7fbf38caf",
+                      sha256="add5982a3ce3b9964b7122dd0d28927b6a9d9abd8f95a89eda18ca76648a0ae8"),
+        "2.8.0": dict(commit="3f878cff5b698b82eea85db2b60d65a2e320850e",
+                      sha256="21d919ad6d96fcc0477c8d4f7b1f7e4295aaec2986e035551ed263c2b1cd52ee")
+    }
+
+    def _should_use_bazel(self):
+        return self.settings.os == 'Macos'
+
+    def package_id(self):
+        # Making sure that changes in minor version or options of `tensorflow-lite` trigger a unique package id
+        # https://docs.conan.io/en/latest/creating_packages/define_abi_compatibility.html
+        self.info.requires["tensorflow-lite"].full_package_mode()
+
+    def configure(self):
+        is_linux = self.settings.os == 'Linux' and self.settings.arch in ('x86_64', 'armv8')
+        is_macos = self.settings.os == 'Macos'
+        if not (is_linux or is_macos):
+            raise ConanInvalidConfiguration(f"Not available for "
+                                            f"({self.settings.os}, {self.settings.arch})")
+
+    def requirements(self):
+        self.requires(f'tensorflow-lite/[>=2.6.0]')
+        self.requires(f'libusb/1.0.22@totemic/stable')
+
+    def build_requirements(self):
+        self.build_requires('flatc/1.12.0')
+        if self._should_use_bazel():
+            self.build_requires('bazel/4.0.0')
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True)
+
+        tf_lite_version = self.deps_cpp_info['tensorflow-lite'].version
+
+        self.output.info(f"TFLite dependency version {tf_lite_version} detected")
+
+        workspace_path = join(self.source_folder, "workspace.bzl")
+        tgt_tf_revision = self.tf_revisions[tf_lite_version]
+
+        # Replacing tensorflow dependency version with the desired one
+        base_commit = "a4dfb8d1a71385bd6d122e4f27f86dcebb96712d"
+        base_sha256 = "cb99f136dc5c89143669888a44bfdd134c086e1e2d9e36278c1eb0f03fe62d76"
+        tools.replace_in_file(workspace_path, base_commit, tgt_tf_revision["commit"])
+        tools.replace_in_file(workspace_path, base_sha256, tgt_tf_revision["sha256"])
+
+        # Make sure bazel uses conan's libusb installation as opposed to the system one
+        tools.patch(patch_file="patches/bazel_conan_libusb_dep.patch")
+
+        tools.patch(patch_file="patches/makefile_fixes.patch")
+
+    def build(self):
+        if self._should_use_bazel():
+            env_vars = dict(CONAN_LIBUSB_ROOT=self.deps_cpp_info["libusb"].rootpath)
+            if self.settings.os == 'Linux' and self.settings.arch == 'armv8':
+                env_vars["CPU"] = "aarch64"
+
+            with tools.environment_append(env_vars):
+                suffix = 'throttled' if self.options.throttled else 'direct'
+                self.run(f"make -C {self.source_folder} libedgetpu-{suffix}")
+        else:
+            autotools = AutoToolsBuildEnvironment(self)
+            suffix = '-throttled' if self.options.throttled else ''
+            autotools.make(target=f"-f {self.source_folder}/makefile_build/Makefile -j6 libedgetpu{suffix}")
+
+    def package(self):
+        variant = 'throttled' if self.options.throttled else 'direct'
+        bin_dir = join(self.source_folder, 'out')
+        include_dir = join(self.source_folder, 'tflite', 'public')
+
+        if self.settings.os == 'Linux':
+            if self._should_use_bazel() and self.settings.arch == 'armv8':
+                arch = 'aarch64'
+            else:
+                # The CMake build pipeline has k8 hardcoded in the path
+                arch = 'k8'
+            lib_name = "libedgetpu.so.1"
+            link_name = "libedgetpu.so"
+        else:
+            arch = 'darwin'
+            lib_name = "libedgetpu.1.dylib"
+            link_name = "libedgetpu.dylib"
+
+        self.copy("LICENSE", src=self.source_folder, dst="licenses", keep_path=False)
+        self.copy("*.h", src=include_dir, dst="include", keep_path=False)
+        self.copy("*", src=f"{bin_dir}/{variant}/{arch}", dst="lib", keep_path=False, symlinks=True)
+
+        with tools.chdir(f"{self.package_folder}/lib"):
+            os.symlink(lib_name, link_name)
+
+        # Remove absolute path to libusb from the mac binary
+        # otool -L libedgetpu.1.0.dylib
+        # otool -l libedgetpu.1.0.dylib | grep LC_RPATH -A2
+        if self.settings.os == 'Macos':
+            # TODO: fix this in the libusb package when building
+            self.output.info("Removing hardcoded path from the libusb dependency")
+            libusb_root = self.deps_cpp_info["libusb"].rootpath
+            self.run(f"install_name_tool -change {libusb_root}/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.0.dylib "
+                     f"{self.package_folder}/lib/{lib_name}")
+
+    def package_info(self):
+        self.cpp_info.libs = ["edgetpu"]

--- a/libedgetpu/conanfile.py
+++ b/libedgetpu/conanfile.py
@@ -5,7 +5,7 @@ from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
 
 
-class EdgeTpuConan(ConanFile):
+class LibEdgeTpuConan(ConanFile):
     name = "libedgetpu"
     description = "Source code for the userspace level runtime driver for Coral devices."
     license = "Apache-2.0"

--- a/libedgetpu/patches/bazel_conan_libusb_dep.patch
+++ b/libedgetpu/patches/bazel_conan_libusb_dep.patch
@@ -1,0 +1,28 @@
+diff --git a/workspace.bzl b/workspace.bzl
+index 16b8af8..13d57a8 100644
+--- a/workspace.bzl
++++ b/workspace.bzl
+@@ -117,13 +117,8 @@ cc_import(
+   visibility = ["//visibility:public"],
+ )
+ """
+-    elif lower_name.startswith("mac os x"):
+-        path = _brew_libusb_path(ctx)
+-        if not path:
+-            path = _port_libusb_path(ctx)
+-            if not path:
+-                fail("Install libusb using MacPorts or Homebrew.")
+-
++    elif lower_name.startswith("mac os x"):
++        path = ctx.os.environ["CONAN_LIBUSB_ROOT"]
+         build_file_content = """
+ cc_library(
+   name = "headers",
+@@ -145,6 +140,7 @@ cc_library(
+ 
+ libusb_repository = repository_rule(
+     implementation = _libusb_impl,
++    environ = ["CONAN_LIBUSB_ROOT"]
+ )
+ 
+ def _properties_impl(ctx):

--- a/libedgetpu/patches/makefile_fixes.patch
+++ b/libedgetpu/patches/makefile_fixes.patch
@@ -1,0 +1,100 @@
+diff --git a/makefile_build/Makefile b/makefile_build/Makefile
+index ef7d290..1547cbf 100644
+--- a/makefile_build/Makefile
++++ b/makefile_build/Makefile
+@@ -10,20 +10,24 @@ BUILDROOT ?= $(MAKEFILE_DIR)/..
+ BUILDDIR := $(BUILDROOT)/out
+ TOBUILDDIR = $(addprefix $(BUILDDIR)/,$(1))
+ MKDIR = if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
+-CC=gcc
+-CXX=g++
++CC?=gcc
++CXX?=g++
+ FLATC=flatc
+ 
+ LIBEDGETPU_CFLAGS := \
+ 	-fPIC \
+ 	-Wall \
+-	-std=c99
++	-std=c99 \
++	$(CFLAGS) \
++	$(CPPFLAGS)
+ 
+ LIBEDGETPU_CXXFLAGS := \
+ 	-fPIC \
+ 	-Wall \
+ 	-std=c++14 \
+-	-DDARWINN_PORT_DEFAULT
++	-DDARWINN_PORT_DEFAULT \
++    $(CXXFLAGS) \
++    $(CPPFLAGS)
+ 
+ LIBEDGETPU_LDFLAGS := \
+ 	-Wl,-Map=$(BUILDDIR)/output.map \
+@@ -31,6 +35,7 @@ LIBEDGETPU_LDFLAGS := \
+ 	-Wl,--soname,libedgetpu.so.1 \
+ 	-Wl,--version-script=$(BUILDROOT)/tflite/public/libedgetpu.lds \
+ 	-fuse-ld=gold \
++	$(LDFLAGS) \
+ 	-lflatbuffers \
+ 	-labsl_flags \
+ 	-labsl_flags_internal \
+@@ -54,14 +59,10 @@ LIBEDGETPU_FW_OUTPUT := $(call TOBUILDDIR, $(BUILDROOT)/driver/usb/usb_latest_fi
+ 
+ LIBEDGETPU_INCLUDES := \
+ 	$(BUILDROOT) \
+-	$(TFROOT) \
+ 	$(BUILDDIR) \
+ 	$(BUILDDIR)/$(BUILDROOT)
+ LIBEDGETPU_INCLUDES := $(addprefix -I,$(LIBEDGETPU_INCLUDES))
+ 
+-LIBEDGETPU_CSRCS := $(TFROOT)/tensorflow/lite/c/common.c
+-LIBEDGETPU_COBJS := $(call TOBUILDDIR,$(patsubst %.c,%.o,$(LIBEDGETPU_CSRCS)))
+-
+ LIBEDGETPU_CCSRCS := \
+ 	$(BUILDROOT)/api/allocated_buffer.cc \
+ 	$(BUILDROOT)/api/buffer.cc \
+@@ -139,8 +140,7 @@ LIBEDGETPU_CCSRCS := \
+ 	$(BUILDROOT)/tflite/custom_op_user_data_direct.cc \
+ 	$(BUILDROOT)/tflite/edgetpu_c.cc \
+ 	$(BUILDROOT)/tflite/edgetpu_delegate_for_custom_op.cc \
+-	$(BUILDROOT)/tflite/edgetpu_delegate_for_custom_op_tflite_plugin.cc \
+-	$(TFROOT)/tensorflow/lite/util.cc
++	$(BUILDROOT)/tflite/edgetpu_delegate_for_custom_op_tflite_plugin.cc
+ LIBEDGETPU_CCOBJS := $(call TOBUILDDIR,$(patsubst %.cc,%.o,$(LIBEDGETPU_CCSRCS)))
+ 
+ # In order to support direct and throttled mode - we need to compile two files
+@@ -180,12 +180,6 @@ firmware:
+ 	done
+ 	@echo "} // namespace" >> $(LIBEDGETPU_FW_OUTPUT)
+ 
+-
+-$(LIBEDGETPU_COBJS) : $(BUILDDIR)/%.o: %.c
+-	@$(MKDIR)
+-	@echo "Compiling $<"
+-	@$(CC) $(LIBEDGETPU_CFLAGS) $(LIBEDGETPU_INCLUDES) -c $< -MD -MT $@ -MF $(@:%o=%d) -o $@
+-
+ $(LIBEDGETPU_CCOBJS) : $(BUILDDIR)/%.o: %.cc
+ 	@$(MKDIR)
+ 	@echo "Compiling $<"
+@@ -201,14 +195,14 @@ $(LIBEDGETPU_STD_CCOBJS) : $(BUILDDIR)/%-throttled.o: %.cc
+ 	@echo "Compiling $<"
+ 	@$(CXX) -DTHROTTLE_EDGE_TPU $(LIBEDGETPU_CXXFLAGS) $(LIBEDGETPU_INCLUDES) -c $< -MD -MT $@ -MF $(@:%o=%d) -o $@
+ 
+-libedgetpu: | firmware $(LIBEDGETPU_FLATC_OBJS) $(LIBEDGETPU_COBJS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_MAX_CCOBJS)
++libedgetpu: | firmware $(LIBEDGETPU_FLATC_OBJS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_MAX_CCOBJS)
+ 	@mkdir -p $(BUILDDIR)/direct/k8
+ 	@echo "Building libedgetpu.so"
+-	@$(CXX) $(LIBEDGETPU_CCFLAGS) $(LIBEDGETPU_LDFLAGS) $(LIBEDGETPU_COBJS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_MAX_CCOBJS) -o $(BUILDDIR)/direct/k8/libedgetpu.so.1.0
+-	@ln -sf $(BUILDDIR)/direct/k8/libedgetpu.so.1.0 $(BUILDDIR)/direct/k8/libedgetpu.so.1
++	@$(CXX) $(LIBEDGETPU_CCFLAGS) $(LIBEDGETPU_LDFLAGS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_MAX_CCOBJS) -o $(BUILDDIR)/direct/k8/libedgetpu.so.1.0
++	@ln -sf libedgetpu.so.1.0 $(BUILDDIR)/direct/k8/libedgetpu.so.1
+ 
+-libedgetpu-throttled: | firmware $(LIBEDGETPU_FLATC_OBJS) $(LIBEDGETPU_COBJS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_STD_CCOBJS)
++libedgetpu-throttled: | firmware $(LIBEDGETPU_FLATC_OBJS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_STD_CCOBJS)
+ 	@mkdir -p $(BUILDDIR)/throttled/k8
+ 	@echo "Building throttled libedgetpu.so"
+-	@$(CXX) $(LIBEDGETPU_CCFLAGS) $(LIBEDGETPU_LDFLAGS) $(LIBEDGETPU_COBJS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_STD_CCOBJS) -o $(BUILDDIR)/throttled/k8/libedgetpu.so.1.0
+-	@ln -sf $(BUILDDIR)/throttled/k8/libedgetpu.so.1.0 $(BUILDDIR)/throttled/k8/libedgetpu.so.1
++	@$(CXX) $(LIBEDGETPU_CCFLAGS) $(LIBEDGETPU_LDFLAGS) $(LIBEDGETPU_CCOBJS) $(LIBEDGETPU_STD_CCOBJS) -o $(BUILDDIR)/throttled/k8/libedgetpu.so.1.0
++	@ln -sf libedgetpu.so.1.0 $(BUILDDIR)/throttled/k8/libedgetpu.so.1

--- a/libedgetpu/test_package/CMakeLists.txt
+++ b/libedgetpu/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(example example.cpp)
+target_link_libraries(example PRIVATE CONAN_PKG::libedgetpu)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/model.tflite DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+

--- a/libedgetpu/test_package/conanfile.py
+++ b/libedgetpu/test_package/conanfile.py
@@ -1,0 +1,15 @@
+from conans import ConanFile, CMake, tools
+
+
+class LibEdgeTpuTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run("bin/example", run_environment=True)

--- a/libedgetpu/test_package/example.cpp
+++ b/libedgetpu/test_package/example.cpp
@@ -1,0 +1,9 @@
+#include <tensorflow/lite/interpreter.h>
+#include <tensorflow/lite/kernels/register.h>
+#include <edgetpu.h>
+
+int main() {
+    tflite::ops::builtin::BuiltinOpResolver resolver;
+    resolver.AddCustom(edgetpu::kCustomOp, edgetpu::RegisterCustomOp());
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Based originally on this https://github.com/totemic/conan-edgetpu/pull/3 and updated to use the [conan-center-index](https://github.com/conan-io/conan-center-index) version of tensorflow-lite.

Benefits of updated `tensorflow-lite` recipe:
- Since v2.6.0 tensorflow added support for building tensorflow-lite with CMake, which works way better
- Building with CMake allows building with XNNPACK (previously that required bazel). We will potentially need it in the future so it's good to upgrade
- All dependencies are mapped to conan packages

I pushed a [few tweaks and and a version bump to v2.8.0](https://github.com/hardsetting/conan-center-index/tree/tensorflow-lite_2.8.0/recipes/tensorflow-lite) that adds support for accelerated quantized inference, in a couple days it will be available officially (need to go through PRs one at a time) but for now I can upload the packages to our artifactory.

Regarding `libedgetpu` I tweaked it so that the `package_id` will change based on the full specification of the `tensorflow-lite` dependency, and specified [>=2.6.0] as requirement instead of pinning a specific version.
If we change the minor version or an option (e.g. `shared`) from the `tensorflow-lite` dependency, this will require a rebuild (I was actually surprised this is not by default, but turns out it's a [tricky problem](https://blog.conan.io/2019/09/27/package-id-modes.html)).

So on the consumer side, the following will ensure that a `libedgetpu` version built against `tensorflow-lite/2.8.0` is used
```python
self.requires("libedgetpu/grouper@totemic/stable")
self.requires("tensorflow-lite/2.8.0@totemic/stable")
``` 
whereas the following will just "default" to the latest version/revision of `tensorflow-lite` available in the local cache
```python
self.requires("libedgetpu/grouper@totemic/stable")
``` 
I tried playing around with bazel and the [experimental generators](https://docs.conan.io/en/latest/reference/conanfile/tools/google.html) hoping to have a cleaner recipe, but it's stil a little too early for that and the project is too tighly coupled with other bazel dependencies and would require too much time.
Hopefully someone else in the community will take care of that :P

Note, only for when building the packages:
`bazel` and `flatc` are specified as build requirement and during cross-compilation we need to specify the [build profile](https://docs.conan.io/en/latest/systems_cross_building/cross_building.html#using-a-profile) with `--profile:build=default` or `-pr:b=default`. If we don't do so, the `host` version of the tools will be fetched, and without `qemu` setup on the system they won't work.

I can later add the extra option to the utility scripts in `sensor-processor` and `embedded-sw` if needed
